### PR TITLE
use 'break-word' also for the openfield

### DIFF
--- a/templates/detail.html
+++ b/templates/detail.html
@@ -44,7 +44,7 @@
 		<td align="left" style="border:hidden;">
 		<b>Reward:</b> {{ areward }}
 		</td><td style="border:hidden"></td></tr><tr>
-		<td align="left" style="border:hidden;">
+		<td align="left" style="border:hidden;overflow-wrap:break-word;">
 		<b>Operation:</b> {{ aoperation }}
 		</td><td style="border:hidden"></td></tr><tr>
 		<td align="left" style="border:hidden;">


### PR DESCRIPTION
Use 'overflow-wrap:break-word' also for the openfield just like for the signature.