### PR TITLE
Added api totalsupply info only as cmc requires.

### DIFF
--- a/explorebis.py
+++ b/explorebis.py
@@ -1643,6 +1643,9 @@ def handler(param1, param2):
 			
 	elif param1 == "info":
 		
+		if param2 == "totalsupply":
+			x = toolsp.getcirc()
+			return json.dumps(str(x[0])).strip('"'), 200, {'Content-Type': 'application/json', 'Cache-Control': 'no-cache'}
 		if param2 == "coinsupply":
 			x = toolsp.getcirc()
 			return json.dumps({'circulating':str(x[1]),'total':str(x[0])}), 200, {'Content-Type': 'application/json', 'Cache-Control': 'no-cache'}


### PR DESCRIPTION
Coinmarketcap requires an API endpoint that specifically displays only the Total Supply on the block explorer in real time as a numerical value that displays JUST THE VALUE and nothing else.

Total supply example of GRS Groestlecoin: URL: http://chainz.cryptoid.info/grs/api.dws?q=totalcoins